### PR TITLE
优先使用本地的reviewer_checklist

### DIFF
--- a/tools/views.py
+++ b/tools/views.py
@@ -11,12 +11,12 @@ logger = logging.getLogger('log')
 
 def review(url):
     logger.info('Starting to review Pull Request')
-    subprocess.call('python3 advisors/review_tool.py -u {} -c'.format(url), shell=True)
+    subprocess.call('python3 advisors/review_tool.py -u {} -c -l'.format(url), shell=True)
 
 
 def edit_review(url, content):
     logger.info('Starting to edit review status')
-    subprocess.call('python3 advisors/review_tool.py -u {} -e {}'.format(url, content), shell=True)
+    subprocess.call('python3 advisors/review_tool.py -u {} -e {} -l'.format(url, content), shell=True)
 
 
 def base_log(pr_url, hook_name, action):


### PR DESCRIPTION
优先使用本地的reviewer_checklist, 之前是优先使用openEuler-Advisor下的review_checklist，现在改为使用本地的reviewer_checklist，减少对第三方项目的依赖。