### PR TITLE
解决因git版本号不同导致对于move动作的解析数据不一致

### DIFF
--- a/advisors/review_tool.py
+++ b/advisors/review_tool.py
@@ -228,6 +228,13 @@ def parse_repo_blacklist_change(repo_changes):
     delete_set, add_to_not_recycle_set, add_to_recycle_set = set(), set(), set()
     for line in repo_changes.splitlines():
         status, item = line.split(maxsplit=1)
+        if status == "R100":
+            rename_list = item.split(maxsplit=1)
+            if len(rename_list) == 2:
+                yaml_name_list = rename_list[-1].split('/')
+                if len(yaml_name_list) > 2 and yaml_name_list[0].strip() == "sig" \
+                        and yaml_name_list[1].strip() == "sig-recycle" and yaml_name_list[2].strip() == "src-openeuler":
+                    return True
         is_yaml_file = item.startswith("sig/") and item.endswith(".yaml")
         if not is_yaml_file:
             continue


### PR DESCRIPTION
解决因git版本号不同导致对于move动作的解析数据不一致， 详细内容分析可见：https://github.com/TomNewChao/openEuler-github-testcase/blob/main/robot-openeuler-ci-tools/review_tool%E5%B7%A5%E5%85%B7%E7%9A%84blacklist%E6%A3%80%E6%9F%A5%E5%A4%B1%E8%B4%A5%E5%AE%9A%E4%BD%8D.docx