### PR TITLE
fix issue about cannot get a new sig maintainers

### DIFF
--- a/advisors/review_tool.py
+++ b/advisors/review_tool.py
@@ -422,12 +422,12 @@ def load_sig_owners(sig_name):
             return None
         subprocess.call('git checkout {}'.format(current_branch), shell=True)
         return owners
+    subprocess.call('git checkout {}'.format(current_branch), shell=True)
     try:
         with open(sig_info_file, 'r') as f:
             sig_info = yaml.load(f.read(), Loader=yaml.Loader)
         maintainers = sig_info['maintainers']
         owners = [('@' + maintainer['gitee_id']) for maintainer in maintainers]
-        subprocess.call('git checkout {}'.format(current_branch), shell=True)
         return owners
     except FileNotFoundError:
         if os.path.exists(owners_file):


### PR DESCRIPTION
修改之前获取master的OWNERS文件失败后未立即切换回工作分支，而导致新增的文件在当前分支（master分支）无法查询。
将切换工作分支操作提前后，流程恢复正常，日志见下图

![image](https://user-images.githubusercontent.com/69004854/177123212-44859884-0404-49f8-8fce-9b61c8f57768.png)
