### PR TITLE
fix issue about retrigger

### DIFF
--- a/tools/views.py
+++ b/tools/views.py
@@ -66,9 +66,11 @@ class ReviewView(GenericAPIView):
             logger.info('Comment Body: {}'.format(comment))
             user_gitee = gitee.Gitee()
             owner, repo, number = pr_url.split('/')[3], pr_url.split('/')[4], pr_url.split('/')[6]
-            latest_review_comment = find_review_comment(user_gitee, owner, repo, number)
-            items = latest_review_comment['body'].splitlines()
             if '/lgtm' in comment.split('\n'):
+                latest_review_comment = find_review_comment(user_gitee, owner, repo, number)
+                if not latest_review_comment:
+                    return JsonResponse({'code': 200, 'msg': 'OK'})
+                items = latest_review_comment['body'].splitlines()
                 latest_review_comment_id = latest_review_comment['id']
                 commenter = data['comment']['user']['login']
                 edit_nums = []


### PR DESCRIPTION
修复"/review retrigger"命令失效的问题

问题根因:  在PR24中引入了限制lgtm修改功能，在该功能的流程中，会获取最后一次的review list内容，并判断评论人是否有权修改lgtm相关条目；在 https://gitee.com/openeuler/community/pulls/4741 这条PR中出现"/review retrigger"命令失效则是由于PR的评论中没有review list

问题调整: 将上述lgtm相关的流程移到具体的case下，并判断是否为空，避免影响其他case

修改前:
![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/b91d2542-3055-4145-856a-6d53294da3db)

![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/7349d298-0702-467c-bce0-62ac27a26137)


修改后:
![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/1a80f0bb-3953-42f8-934a-027920b2ead2)

![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/09295826-00b3-4e50-8ce3-3eb5dcc682a0)
