### PR TITLE
fix issue for no repositories sigs

### DIFF
--- a/tools/views.py
+++ b/tools/views.py
@@ -66,9 +66,11 @@ class ReviewView(GenericAPIView):
             logger.info('Comment Body: {}'.format(comment))
             user_gitee = gitee.Gitee()
             owner, repo, number = pr_url.split('/')[3], pr_url.split('/')[4], pr_url.split('/')[6]
-            latest_review_comment = find_review_comment(user_gitee, owner, repo, number)
-            items = latest_review_comment['body'].splitlines()
             if '/lgtm' in comment.split('\n'):
+                latest_review_comment = find_review_comment(user_gitee, owner, repo, number)
+                if not latest_review_comment:
+                    return JsonResponse({'code': 200, 'msg': 'OK'})
+                items = latest_review_comment['body'].splitlines()
                 latest_review_comment_id = latest_review_comment['id']
                 commenter = data['comment']['user']['login']
                 edit_nums = []
@@ -137,7 +139,7 @@ class ReviewView(GenericAPIView):
                         for line in lines:
                             if line.strip().startswith("/review "):
                                 sets = line.strip().split(maxsplit=1)[1]
-                                sets = filter_review(sets, lgtm_items, len(items))
+                                sets = filter_review(sets, lgtm_items, len(lgtm_items))
                                 sets_li.append(sets)
                         contents = " ".join(sets_li)
                         if contents:


### PR DESCRIPTION
修复因sig的sig-info.yaml中无repositories字段导致的PR无法评论审视清单的问题
------
问题原因：在advisors/review_tool.py的check_committer_repo_changes方法中，需要获取变更的sig-info.yaml中的repositories以解析变更前后对committers的影响，而未考虑sig-info.yaml无repositories字段，导致变更的sig-info.yaml在变更前或变更后无repositories字段时无法在PR中评论审视清单

修复前：
![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/f96effee-6760-4c82-b417-d494ebba478a)

修复后：
![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/34a52383-1846-4318-9c09-481def85d9be)
