### PR TITLE
fix issue when sig-info.yaml has no field `repositories`

### DIFF
--- a/advisors/review_tool.py
+++ b/advisors/review_tool.py
@@ -726,26 +726,28 @@ def check_committer_repo_changes():
             remote_repos = yaml.load(remote_sig_info, Loader=yaml.Loader).get('repositories')
             current_committers = {}
             remote_committers = {}
-            for i in current_repos:
-                if 'committers' not in i.keys():
-                    continue
-                committers = [x['gitee_id'] for x in i['committers']]
-                for committer in committers:
-                    if committer not in current_committers.keys():
-                        current_committers[committer] = i['repo']
-                    else:
-                        for repo in i['repo']:
-                            current_committers[committer].append(repo)
-            for j in remote_repos:
-                if 'committers' not in j.keys():
-                    continue
-                committers = [x['gitee_id'] for x in j['committers']]
-                for committer in committers:
-                    if committer not in remote_committers.keys():
-                        remote_committers[committer] = j['repo']
-                    else:
-                        for repo in j['repo']:
-                            remote_committers[committer].append(repo)
+            if current_repos:
+                for i in current_repos:
+                    if 'committers' not in i.keys():
+                        continue
+                    committers = [x['gitee_id'] for x in i['committers']]
+                    for committer in committers:
+                        if committer not in current_committers.keys():
+                            current_committers[committer] = i['repo']
+                        else:
+                            for repo in i['repo']:
+                                current_committers[committer].append(repo)
+            if remote_repos:
+                for j in remote_repos:
+                    if 'committers' not in j.keys():
+                        continue
+                    committers = [x['gitee_id'] for x in j['committers']]
+                    for committer in committers:
+                        if committer not in remote_committers.keys():
+                            remote_committers[committer] = j['repo']
+                        else:
+                            for repo in j['repo']:
+                                remote_committers[committer].append(repo)
             for crt_committer in current_committers:
                 if crt_committer not in remote_committers.keys():
                     committers_changed_repos[crt_committer] = current_committers[crt_committer]


### PR DESCRIPTION
识别sig-info.yaml不存在repositories字段的场景，并修复场景对应的异常

修改前:
![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/d23040e3-1ac4-475a-99be-9193fa58f50b)


修改后:
![image](https://github.com/opensourceways/robot-openeuler-ci-tools/assets/69004854/3bbf6369-8db2-4141-b69d-b648812a5e3b)
